### PR TITLE
Add definitions of card terms

### DIFF
--- a/manual.txt
+++ b/manual.txt
@@ -2740,6 +2740,8 @@ Clicking on "Save Image" will save an image of the statistics to a file and open
 it in your default image editor, to make it easy to share your statistics with
 others.
 
+The stats window uses some terms that you may not be familiar with:
+
  Mature ::
   A mature card is one that has an interval of 21 days or greater.
  Young ::


### PR DESCRIPTION
Defined "mature," "young," "learn," "relearn," and "unseen." Also corrected a typo and a spot I thought was unclear immediately above the definition.

There are two commits because I forgot to include any introduction to the list of terms the first time around (and had already pushed before I noticed). >__<
