### PR TITLE
Update Qt doc links in the add-on guide.

### DIFF
--- a/addons.txt
+++ b/addons.txt
@@ -39,7 +39,7 @@ in command line programs to access Anki decks without the GUI.
 
 'aqt' contains the UI part of Anki. Anki's UI is built upon PyQt, Python
 bindings for the cross-platform GUI toolkit Qt. PyQt follows Qt's API very
-closely, so the http://doc.qt.io/qt-4.8/index.html[Qt documentation] can
+closely, so the http://doc.qt.io/qt-5/index.html[Qt documentation] can
 be very useful when you want to know how to use a particular GUI component.
 
 When Anki starts up, it checks for .py files in the Documents/Anki/addons
@@ -438,7 +438,7 @@ hook to be added.
 
 = Qt =
 
-As mentioned above, the http://doc.qt.io/qt-4.8/index.html[Qt
+As mentioned above, the http://doc.qt.io/qt-5/index.html[Qt
 documentation] is invaluable for learning how to display different GUI
 widgets.
 


### PR DESCRIPTION
The links still remain pointing Qt 4.8 documents.